### PR TITLE
Enable CORS for compile endpoint

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -32,6 +32,15 @@ const SOLC_LIST_URL = "https://binaries.soliditylang.org/bin/list.json";
 // ============================ App ============================
 const app = express();
 app.use(helmet());
+app.use((req, res, next) => {
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  res.header("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
+  if (req.method === "OPTIONS") {
+    return res.sendStatus(204);
+  }
+  next();
+});
 app.use(morgan("tiny"));
 app.use(bodyParser.json({ limit: "512kb" }));
 app.use(rateLimit({ windowMs: 60_000, max: 30, standardHeaders: true, legacyHeaders: false }));


### PR DESCRIPTION
## Summary
- allow cross-origin requests by adding CORS headers

## Testing
- `npm test`
- `node src/server.js & sleep 1; kill $!`


------
https://chatgpt.com/codex/tasks/task_e_689e345954e4832d8eba8359d004380f